### PR TITLE
修改注入判断

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## 安装
 
 ~~~
-composer require topthink/think-trace
+composer remove topthink/think-trace
+composer require hongfs/think-trace:tree-1
 ~~~
 
 ## 配置

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "topthink/think-trace",
+    "name": "hongfs/think-trace",
     "description": "thinkphp debug trace",
     "license": "Apache-2.0",
     "authors": [

--- a/src/TraceDebug.php
+++ b/src/TraceDebug.php
@@ -71,7 +71,7 @@ class TraceDebug
         $response = $next($request);
 
         // Trace调试注入
-        if ($debug) {
+        if ($debug && $this->app->isDebug()) {
             $data = $response->getContent();
             $this->traceDebug($response, $data);
             $response->content($data);


### PR DESCRIPTION
方便路由中间件可以临时关闭调试模式，阻止部分路由输出调试信息