### PR TITLE
fixes: 在控制器中动态更改debug，还是注入了trace

### DIFF
--- a/src/TraceDebug.php
+++ b/src/TraceDebug.php
@@ -56,10 +56,8 @@ class TraceDebug
      */
     public function handle($request, Closure $next)
     {
-        $debug = $this->app->isDebug();
-
         // 注册日志监听
-        if ($debug) {
+        if ($this->app->isDebug()) {
             $this->log = [];
             $this->app->event->listen(LogWrite::class, function ($event) {
                 if (empty($this->config['channel']) || $this->config['channel'] == $event->channel) {
@@ -71,7 +69,7 @@ class TraceDebug
         $response = $next($request);
 
         // Trace调试注入
-        if ($debug) {
+        if ($this->app->isDebug()) {
             $data = $response->getContent();
             $this->traceDebug($response, $data);
             $response->content($data);


### PR DESCRIPTION
场景描述：在有的接口，无论是否为调试模式，都想强行`不注入trace`。比如根据文章id 生成js脚本，用于前端<script>标签引入。如果注入了trace，将会产生报错。

有问题的使用方式：
```php
App::debug(false);
return "test";
```

原因：在源码中，trace中间件 执行$next()，之后，判断debug是用变量，没有重新判断